### PR TITLE
use single-line description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(
     version = str(VERSION),
     author = "EasyBuild community",
     author_email = "easybuild@lists.ugent.be",
-    description = """EasyBuild is a software build
-and installation framework that allows you to manage (scientific) software
+    description = """EasyBuild is a software build \
+and installation framework that allows you to manage (scientific) software \
 on High Performance Computing (HPC) systems in an efficient way.""",
     license = "GPLv2",
     keywords = "software build building installation installing compilation HPC scientific",


### PR DESCRIPTION
Recent versions of setuptools require the `description` field to be a single line, or else:

```
Upload failed (400): summary: Multiple lines are not allowed.
error: Upload failed (400): summary: Multiple lines are not allowed.
```