### PR TITLE
document --backup-modules

### DIFF
--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -24,8 +24,8 @@ The location of the backed up module file will be printed, as well as a "unified
 
 .. _backup_modules_disable:
 
-Disabling backup of modules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Disabling automatic backup of modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When ``--skip`` or ``--module-only`` is used, backing up of existing modules is enabled automatically.
 

--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -1,0 +1,96 @@
+.. _backup_modules:
+
+Backing up of existing modules (``--backup-modules``)
+-----------------------------------------------------
+
+While regenerating existing module files, you may want to preserve the existing module files
+to compare and assess that the changes in the newly generated module file match expectations.
+
+Backing up of existing modules can be enabled with ``--backup-modules``.
+
+Backups are stored in the same directory as where the module file was located,
+and the files are given an additional extention of the form ``.bak_<year><month><day><hour><min><sec>``.
+
+* With module files in Tcl syntax, the backup module file is hidden by adding a leading dot to the filename; 
+  this is done to avoid that it is displayed as a normal module in ``module avail``.
+* With module files in Lua syntax, the backup module file is not made hidden since the additional
+  ``.bak_*`` extension prevents Lmod from picking it up as a valid module file (only files ending in ``.lua``
+  are considered to be module files)
+
+The location of the backed up module file will be printed, as well as a "unified diff" comparison
+(very similar to what ``diff -u`` produces) between the backed up module file and the newly generated module file
+(or a message mentioning that no differences were found).
+
+
+.. _backup_modules_disable:
+
+Disabling backup of modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``--skip`` or ``--module-only`` is used, backing up of existing modules is enabled automatically.
+
+This can be disabled with ``--disable-backup-modules``.
+
+
+.. _backup_modules_example:
+
+Example
+~~~~~~~
+
+Suppose existing modules in both Tcl & Lua syntax are present for bzip2 1.0.6.
+Both are missing an update statement for $PATH because the ``/bin`` subdirectory was missing in the installation,
+for the purpose of this example::
+
+    $ ls -la $EASYBUILD_PREFIX/modules/all/bzip2
+    total 16
+    drwxr-xr-x  2 example  example   136 Aug 24 10:20 .
+    drwxr-xr-x  3 example  example   102 Aug 24 10:18 ..
+    -rw-r--r--  1 example  example  1256 Aug 24 10:19 1.0.6
+    -rw-r--r--  1 example  example  1303 Aug 24 10:18 1.0.6.lua
+
+
+Using ``--force`` and ``--backup-modules``, we can reinstall the ``bzip2/1.0.6`` modules
+and get a clear view on what has changed.
+
+To reinstall the ``bzip2/1.0.6`` module in Lua syntax while retaining a backup of the existing module::
+
+    $ eb bzip2-1.0.6.eb --module-syntax=Lua --force --backup-modules
+    ...
+    == creating build dir, resetting environment...
+    == backup of existing module file stored at /example/modules/all/bzip2/1.0.6.lua.bak_20170824102603
+    ...
+    == creating module...
+    == comparing module file with backup /example/modules/all/bzip2/1.0.6.lua.bak_20170824102603; diff is:
+    --- /example/modules/all/bzip2/1.0.6.lua.bak_20170824102603
+    +++ /example/modules/all/bzip2/1.0.6.lua
+    @@ -25,9 +25,10 @@
+     prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib"))
+     prepend_path("LIBRARY_PATH", pathJoin(root, "lib"))
+     prepend_path("MANPATH", pathJoin(root, "man"))
+    +prepend_path("PATH", pathJoin(root, "bin"))
+     setenv("EBROOTBZIP2", root)
+     setenv("EBVERSIONBZIP2", "1.0.6")
+     setenv("EBDEVELBZIP2", pathJoin(root, "easybuild/bzip2-1.0.6-easybuild-devel"))
+
+    ...
+    
+Equivalently, we can reinstall the module in Tcl syntax using::
+
+    $ eb bzip2-1.0.6.eb --module-syntax=Tcl --force --backup-modules
+
+Afterwards, both the newly generated modules and the backups are in place::
+
+    $ ls -la $EASYBUILD_PREFIX/modules/all/bzip2
+    total 32
+    drwxr-xr-x  2 example  example   204 Aug 24 10:23 .
+    drwxr-xr-x  3 example  example   102 Jul 11 10:18 ..
+    -rw-r--r--  1 example  example  1227 Aug 24 10:23 .1.0.6.bak_20170824102412
+    -rw-r--r--  1 example  example  1256 Jul 11 01:24 1.0.6
+    -rw-r--r--  1 example  example  1303 Jul 11 01:26 1.0.6.lua
+    -rw-r--r--  1 example  example  1259 Aug 24 10:23 1.0.6.lua.bak_20170824102603
+
+Cleaning up the backup module files can be done with the following command (for example)::
+
+    $ find $EASYBUILD_PREFIX/modules/all/bzip2 -name '*.bak*' | xargs rm -v
+    /example/modules/all/bzip2/.1.0.6.bak_20170824102412
+    /example/modules/all/bzip2/1.0.6.lua.bak_20170824102603

--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -37,8 +37,10 @@ This can be disabled with ``--disable-backup-modules``.
 Example
 ~~~~~~~
 
-Suppose existing modules in both Tcl & Lua syntax are present for bzip2 1.0.6.
-Both are missing an update statement for $PATH because the ``/bin`` subdirectory was missing in the installation,
+Suppose existing modules in both Tcl & Lua syntax are present (``bzip2/1.0.6``).
+
+Both these module files are missing an update statement for $PATH
+because the ``/bin`` subdirectory was missing in the installation,
 for the purpose of this example::
 
     $ ls -la $EASYBUILD_PREFIX/modules/all/bzip2

--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -82,12 +82,12 @@ Afterwards, both the newly generated modules and the backups are in place::
 
     $ ls -la $EASYBUILD_PREFIX/modules/all/bzip2
     total 32
-    drwxr-xr-x  2 example  example   204 Aug 24 10:23 .
+    drwxr-xr-x  2 example  example   204 Aug 24 10:26 .
     drwxr-xr-x  3 example  example   102 Jul 11 10:18 ..
-    -rw-r--r--  1 example  example  1227 Aug 24 10:23 .1.0.6.bak_20170824102412
+    -rw-r--r--  1 example  example  1227 Aug 24 10:24 .1.0.6.bak_20170824102412
     -rw-r--r--  1 example  example  1256 Jul 11 01:24 1.0.6
     -rw-r--r--  1 example  example  1303 Jul 11 01:26 1.0.6.lua
-    -rw-r--r--  1 example  example  1259 Aug 24 10:23 1.0.6.lua.bak_20170824102603
+    -rw-r--r--  1 example  example  1259 Aug 24 10:26 1.0.6.lua.bak_20170824102603
 
 Cleaning up the backup module files can be done with the following command (for example)::
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -5,6 +5,7 @@ Changelog for EasyBuild documentation
 
 (for EasyBuild release notes, see :ref:`release_notes`)
 
+* **release 20170824.01** (`Aug 24th 2017`): document ``--backup-modules`` (see :ref:`backup_modules`)
 * **release 20170712.01** (`July 12th 2017`): update release notes for EasyBuild v3.3.1 (see :ref:`release_notes_eb331`)
 * **release 20170708.01** (`July 8th 2017`): add documentation on :ref:`github_merge_pr`
 * **release 20170705.01** (`July 5th 2017`): clarify :ref:`contributing_review_process_pr_requirements`, add page listing :ref:`maintainers`

--- a/docs/Partial_installations.rst
+++ b/docs/Partial_installations.rst
@@ -8,12 +8,9 @@ with the installation procedure being performed by EasyBuild, updating existing 
 or after changing the EasyBuild configuration (e.g., switching to module files in Lua syntax or a different module
 naming scheme).
 
-* :ref:`partial_installation_stop`
-* :ref:`partial_installation_skip`
-* :ref:`module_only`
-
-  * :ref:`module_only_only_regenerate`
-  * :ref:`module_only_additional`
+.. contents::
+    :depth: 3
+    :backlinks: none
 
 .. _partial_installation_stop:
 
@@ -103,6 +100,9 @@ Example usage::
   *always* be skipped when the installation of a particular software package is performed, no matter whether the
   software or corresponding module is already available or not.
 
+.. note:: When ``--skip`` is used, a backup is created for all existing module files that are regenerated.
+          To disable backing up of module files, use ``--disable-backup-modules`` (see also :ref:`backup_modules`).
+
 .. _module_only:
 
 Only (re)generating (additional) module files using ``--module-only``
@@ -126,6 +126,9 @@ Use cases:
 
 * :ref:`module_only_only_regenerate`
 * :ref:`module_only_additional`
+
+.. note:: When ``--module-only`` is used, a backup is created for all existing module files that are regenerated.
+          To disable backing up of module files, use ``--disable-backup-modules`` (see also :ref:`backup_modules`).
 
 .. _module_only_only_regenerate:
 
@@ -190,18 +193,6 @@ Example usage:
 
    $ ls -l /home/example/.local/modules/all/GCC/4.8.2
    -rw-rw-r-- 1 example example 1064 Apr 30 10:54 /home/example/.local/modules/all/GCC/4.8.2
-
-While regenerating existing module files, one might want to preserve the old modules to compare and assess that the
-changes matches the expectations. ``--backup-modules`` does exactly that. This option just works when combined with
-``--module-only``, and its specific behaviour depends on the module syntax used:
-
-* When using TCL modules, the backup is hidden with a leading dot, and has a ``.bck`` extension. The leading dot is
-  necessary to avoid being displayed as a normal module.
-* When using Lua modules, the backup has a ``.bck`` extension, but no leading dot, since the extension prevents Lmod
-  from showing the module.
-
-For convenience, a warning will be issued when an old module has been found. The warning will include the output of
-``diff -u old_module new_module``, if there is any difference between them.
 
 .. _module_only_additional:
 

--- a/docs/Partial_installations.rst
+++ b/docs/Partial_installations.rst
@@ -191,6 +191,18 @@ Example usage:
    $ ls -l /home/example/.local/modules/all/GCC/4.8.2
    -rw-rw-r-- 1 example example 1064 Apr 30 10:54 /home/example/.local/modules/all/GCC/4.8.2
 
+While regenerating existing module files, one might want to preserve the old modules to compare and assess that the
+changes matches the expectations. ``--backup-modules`` does exactly that. This option just works when combined with
+``--module-only``, and its specific behaviour depends on the module syntax used:
+
+* When using TCL modules, the backup is hidden with a leading dot, and has a ``.bck`` extension. The leading dot is
+  necessary to avoid being displayed as a normal module.
+* When using Lua modules, the backup has a ``.bck`` extension, but no leading dot, since the extension prevents Lmod
+  from showing the module.
+
+For convenience, a warning will be issued when an old module has been found. The warning will include the output of
+``diff -u old_module new_module``, if there is any difference between them.
+
 .. _module_only_additional:
 
 Generating additional module files

--- a/docs/Using_the_EasyBuild_command_line.rst
+++ b/docs/Using_the_EasyBuild_command_line.rst
@@ -262,6 +262,9 @@ Use ``eb --rebuild`` to rebuild a given easyconfig/module.
 .. tip:: Combine ``--rebuild`` with ``--dry-run`` to get a good view on which installations will be rebuilt.
    (cfr. :ref:`get_an_overview`)
 
+.. note:: To create a backup of existing modules that are regenerated when ``--rebuild`` is used,
+          use ``--backup-modules`` (see also :ref:`backup_modules`).
+
 .. _force_option:
 
 Forced reinstallation, ``--force`` / ``-f``
@@ -274,6 +277,9 @@ The behavior of ``--force`` is the same as ``--rebuild`` and ``--ignore-osdeps``
 
 .. tip:: Combine ``--force`` with ``--dry-run`` to get a good view on which installations will be forced.
    (cfr. :ref:`get_an_overview`)
+
+.. note:: To create a backup of existing modules that are regenerated when ``--force`` is used,
+          use ``--backup-modules`` (see also :ref:`backup_modules`).
 
 .. _searching_for_easyconfigs:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ copyright = '2012-2017, Ghent University, CC-BY-SA'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '3.3.1'  # this is meant to reference the version of EasyBuild
+version = '3.4.0dev'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
 release = '20170824.01'  # this is meant to reference the version of the documentation itself
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ copyright = '2012-2017, Ghent University, CC-BY-SA'
 # The short X.Y version.
 version = '3.3.1'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
-release = '20170712.01'  # this is meant to reference the version of the documentation itself
+release = '20170824.01'  # this is meant to reference the version of the documentation itself
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Advanced usage topics
     :maxdepth: 2
 
     Archived-easyconfigs
+    Backup-modules
     Common-toolchains
     Contributing
     Controlling_compiler_optimization_flags

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Advanced usage topics
     :maxdepth: 2
 
     Archived-easyconfigs
-    Backup-modules
+    Backup_modules
     Common-toolchains
     Contributing
     Controlling_compiler_optimization_flags


### PR DESCRIPTION
Support for `--backup-modules` was merged to be included in EasyBuild v3.4.0 in https://github.com/easybuilders/easybuild-framework/pull/2134.

This leverages #365; since @damianam is on leave I looked into extending it a bit.

Preview at http://boegel-eb.readthedocs.io/en/backup_modules/Backup_modules.html