### PR TITLE
Run codespell on docs

### DIFF
--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -9,7 +9,7 @@ to compare and assess that the changes in the newly generated module file match 
 Backing up of existing modules can be enabled with ``--backup-modules``.
 
 Backups are stored in the same directory as where the module file was located,
-and the files are given an additional extention of the form ``.bak_<year><month><day><hour><min><sec>``.
+and the files are given an additional extension of the form ``.bak_<year><month><day><hour><min><sec>``.
 
 * With module files in Tcl syntax, the backup module file is hidden by adding a leading dot to the filename; 
   this is done to avoid that it is displayed as a normal module in ``module avail``.

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -126,7 +126,7 @@ If multiple configuration files are listed via a mechanism listed above, the set
 configuration file have preference over the others.
 
 Each available configuration file will be used, and the configuration settings specified in these files
-will be retained according to the order of preference as indicated above: settings in configuration files specfied via
+will be retained according to the order of preference as indicated above: settings in configuration files specified via
 ``--configfiles`` override those in configuration files specified via ``$EASYBUILD_CONFIGFILES``, which in turns override
 settings in default configuration files.
 

--- a/docs/Containers.rst
+++ b/docs/Containers.rst
@@ -92,7 +92,7 @@ There are a couple of specific requirements for the base container image:
 
 The ``easybuild`` user will be used when running EasyBuild to install the specified software stack.
 
-.. note:: The generated container recipe currrently hardcodes some of this.
+.. note:: The generated container recipe currently hardcodes some of this.
           We intend to make this more configurable in a future version of EasyBuild.
 
 
@@ -315,7 +315,7 @@ Configuration
 -------------
 
 .. note:: You can specify each of these configuration options either as options to the ``eb`` command,
-          via the equivalent ``$EASYBUILD_CONTAINER*`` environment variable, or via an EasyBuild configuation file;
+          via the equivalent ``$EASYBUILD_CONTAINER*`` environment variable, or via an EasyBuild configuration file;
           see :ref:`configuration_types`.
 
 .. _containers_cfg_path:

--- a/docs/Detecting_loaded_modules.rst
+++ b/docs/Detecting_loaded_modules.rst
@@ -27,7 +27,7 @@ with the software installations performed by EasyBuild, i.e.:
 
 * they may cause installations failures, for example due to incompatibilities with the modules being loaded
   during the installation procedure being performed;
-* they may cause installations to work in that particular environment, for example by providing a neccessary
+* they may cause installations to work in that particular environment, for example by providing a necessary
   dependency
 
 Since manually loading modules may affect the reproducibility of software installations, it should be discouraged.

--- a/docs/Hooks.rst
+++ b/docs/Hooks.rst
@@ -176,7 +176,7 @@ it will be replaced with the actual value of the ``version`` easyconfig paramete
 This can be avoided by temporarily disabling templating via ``self.cfg.enable_templating``, should the need arise.
 
 There is one notable exception to this: templates in easyconfig parameters are *not* resolved in ``parse_hook``,
-because templating has been disabled explicitely before ``parse_hook`` is called;
+because templating has been disabled explicitly before ``parse_hook`` is called;
 this helps significantly to simplify manipulating of easyconfig parameter values
 (see also :ref:`hooks_caveats_manipulating`).
 
@@ -205,7 +205,7 @@ More specifically, the following approach will *not* work in any of the (step) h
 
     def pre_fetch_hook(self):
         "Example of pre-fetch hook to manipulate list of patches."
-        # this does NOT have the intented affect in any pre- or post-step hook
+        # this does NOT have the intended affect in any pre- or post-step hook
         self.cfg['patches'].append('example.patch')
 
 The problem here is that the value obtained via ``self.cfg['patches']`` is not a reference

--- a/docs/Implementing-easyblocks.rst
+++ b/docs/Implementing-easyblocks.rst
@@ -214,8 +214,8 @@ In the class definition, one or more '``*_step``' methods are redefined, to impl
 in the build and installation procedure.
 
 Each easyblock *must* implement the ``configure``, ``build`` and ``install`` steps, since these are not implemented
-in the abstract ``EasyBlock`` class. This could be done explicitely by redefining the corresponding ``*_step`` methods,
-or implicitely by deriving from existing (generic) easyblocks.
+in the abstract ``EasyBlock`` class. This could be done explicitly by redefining the corresponding ``*_step`` methods,
+or implicitly by deriving from existing (generic) easyblocks.
 
 
 .. _implementing_easyblocks_deriving:
@@ -227,7 +227,7 @@ When implementing an easyblock, it is common to derive from an existing (usually
 and to leverage the functionality provided by it. This approach is typically used when only a specific part
 of the build and installation procedure needs to be customised.
 
-In the (fictious) example below, we derive from the generic ``ConfigureMake`` easyblock to redefine the ``configure``
+In the (fictitious) example below, we derive from the generic ``ConfigureMake`` easyblock to redefine the ``configure``
 step. In this case, we are *extending* the ``configure`` step as implemented by ``ConfigureMake`` rather than
 redefining it entirely, since we call out to the original ``configure_step`` method at the end.
 
@@ -330,7 +330,7 @@ number of useful functions related to this, including:
 
 * ``copy_file(<src>, <dest>)`` to copy an existing file
 
-* ``apply_regex_substitutions(<path>, <list of regex substitions>)`` to patch an existing file
+* ``apply_regex_substitutions(<path>, <list of regex substitutions>)`` to patch an existing file
 
 All of these functions are provided by the ``easybuild.tools.filetools`` module.
 

--- a/docs/Including_additional_Python_modules.rst
+++ b/docs/Including_additional_Python_modules.rst
@@ -139,7 +139,7 @@ components (compilers, MPI libraries, BLAS/LAPACK/FFT libraries, ...) can be don
 
 EasyBuild will determine whether the Python module is a *toolchain definition* or implements support for an *additional
 toolchain component* based on the name of the directory in which it is located. Implementations of toolchain components
-are expeced to be located in a directory named according to the type of component (``compiler``, ``mpi``, ``linalg``
+are expected to be located in a directory named according to the type of component (``compiler``, ``mpi``, ``linalg``
 or ``fft``).
 
 To verify that EasyBuild is aware of the included toolchains, ``--list-toolchains`` can be used.

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -401,7 +401,7 @@ A couple of shell tools may be required, depending on the particular use case (i
 * shell builtin commands:
 
   * ``type``, for inspecting the ``module`` function (if defined)
-  * ``ulimit``, for quering user limits
+  * ``ulimit``, for querying user limits
 
 * tools for unpacking (source) archives:
 
@@ -409,9 +409,9 @@ A couple of shell tools may be required, depending on the particular use case (i
   * occasionally required: ``unzip``, ``unxz``
 
 * ``patch``, for applying patch files to unpacked sources (relatively common)
-* ``rpm`` or ``dpkg``, for quering OS dependencies (only needed occasionally)
+* ``rpm`` or ``dpkg``, for querying OS dependencies (only needed occasionally)
 * ``locate``, only as a (poor mans) fallback to ``rpm``/``dpkg`` (rarely needed)
-* ``sysctl``, for quering system characteristics (only required on non-Linux systems)
+* ``sysctl``, for querying system characteristics (only required on non-Linux systems)
 
 .. _required_modules_tool:
 
@@ -443,7 +443,7 @@ Supported module tools:
 
 .. note::
   For Lmod specifically, EasyBuild will try to fall back to finding the ``lmod`` binary via the ``$LMOD_CMD``
-  environment variable, in case ``lmod`` is not availabe in ``$PATH``.
+  environment variable, in case ``lmod`` is not available in ``$PATH``.
 
   In EasyBuild versions *prior* to 2.1.1, the path specified by ``$LMOD_CMD`` was (erroneously) preferred over the
   (first) ``lmod`` binary available via ``$PATH``.

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -592,7 +592,7 @@ This takes care of all the steps required to make a contribution, i.e.:
 * moving easyconfig files to the right location in the repository (e.g. ``easybuild/easyconfigs/e/EasyBuild/``)
 * staging and committing the files in the feature branch
 * pushing the feature branch to your fork of the relevant EasyBuild repository on GitHub
-* creating the pull request, targetting the ``develop`` branch of the central EasyBuild repository (e.g. ``easybuilders/easybuild-easyconfigs``)
+* creating the pull request, targeting the ``develop`` branch of the central EasyBuild repository (e.g. ``easybuilders/easybuild-easyconfigs``)
 
 It should be clear that automating this whole procedure with a single simple ``eb`` command greatly lowers the bar
 for contributing, especially since it even alleviates the need for interacting directly with ``git`` entirely!

--- a/docs/Release_notes.rst
+++ b/docs/Release_notes.rst
@@ -390,7 +390,7 @@ bugfix/update release
   - solve '``version UUID_1.0 not found``' problem in LibUUID easyconfigs (`#6962 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6962>`_)
   - eliminate dependency on ancient problematic LibUUID library, replace with util-linux (`#6963 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6963>`_)
   - force building of ``ccmake`` for CMake 3.12.1 + fix deps (`#6967 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6967>`_)
-  - fix broken installation for Python 3.6.2 & 3.6.3 with PyNaCl as dep for paramiko extension by explicitely including previous PyNaCl version as extension (`#6971 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6971>`_)
+  - fix broken installation for Python 3.6.2 & 3.6.3 with PyNaCl as dep for paramiko extension by explicitly including previous PyNaCl version as extension (`#6971 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6971>`_)
   - fix source URL for ADMIXTURE (no https) + add SHA256 checksum (`#6982 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6982>`_)
   - add missing NSS/DBus dependencies to Qt 5.10.1 easyconfigs built with foss toolchain to ensure that QtWebEngine component gets installed (`#7005 <https://github.com/easybuilders/easybuild-easyconfigs/pull/7005>`_)
   - add '``openssl``' OS deps in Perl 5.28.0 easyconfig for ``Net::ssleay`` (`#7008 <https://github.com/easybuilders/easybuild-easyconfigs/pull/7008>`_)
@@ -924,7 +924,7 @@ feature release
   * add 10 packages that were previously downloaded in Python 3.6.4 easyconfigs (`#6081 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6081>`_)
   * add patch for Tensorflow 1.6 & 1.7 to include missing -lrt link flag (needed in CentOS6) (`#6089 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6089>`_)
   * fix checksums for R extensions that were updated in place in easyconfigs for R versions 3.4.3 & 3.4.4 (`#6118 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6118>`_)
-  * include pkg-config as build dep in recent R easyconfigs (required for atleast nloptr) (`#6122 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6122>`_)
+  * include pkg-config as build dep in recent R easyconfigs (required for at least nloptr) (`#6122 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6122>`_)
   * remove Intel-specific workaround for '``undefined symbol: __stack_chk_guard``' issue from Python 3.6.4 foss/2018a easyconfig (`#6130 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6130>`_)
   * add configopt ``--without-matlab``/``octave`` to all NLopt easyconfigs (`#6132 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6132>`_)
   * also consider ``lib64`` in ``sanity_check_paths`` for Bison 3.0.4 (`#6170 <https://github.com/easybuilders/easybuild-easyconfigs/pull/6170>`_)
@@ -1409,7 +1409,7 @@ feature release
   * updates GAMESS-US easyblock for version 20170420R1 + move ``ddikick.x`` when ``ddi_comm`` is set to '``sockets``' (`#1221 <https://github.com/easybuilders/easybuild-easyblocks/pull/1221>`_)
   * update MRtrix easyblock for 3.0 & beyond + use ``copy`` function (`#1230 <https://github.com/easybuilders/easybuild-easyblocks/pull/1230>`_)
   * update ROOT easyblock to support recent versions that require using CMake, add sanity check, clean up/enhance ``make_module*`` (`#1236 <https://github.com/easybuilders/easybuild-easyblocks/pull/1236>`_)
-  * enhance icc easyblock to inlude multipath include dir in ``$CPATH`` (`#1237 <https://github.com/easybuilders/easybuild-easyblocks/pull/1237>`_, `#1242 <https://github.com/easybuilders/easybuild-easyblocks/pull/1242>`_)
+  * enhance icc easyblock to include multipath include dir in ``$CPATH`` (`#1237 <https://github.com/easybuilders/easybuild-easyblocks/pull/1237>`_, `#1242 <https://github.com/easybuilders/easybuild-easyblocks/pull/1242>`_)
 
 * various bug fixes, including:
 
@@ -1890,7 +1890,7 @@ bugfix/update release
 
     * required for Intel MPI and Intel MKL version 2017.2.174
 
-  * remove ``prefix_opt`` as custom easyconfig paramter for Qt easyblock (`#1120 <https://github.com/easybuilders/easybuild-easyblocks/pull/1120>`_)
+  * remove ``prefix_opt`` as custom easyconfig parameter for Qt easyblock (`#1120 <https://github.com/easybuilders/easybuild-easyblocks/pull/1120>`_)
 
 * various bug fixes, including:
 
@@ -2411,7 +2411,7 @@ feature release
 
 * various enhancements, including:
 
-  * extend OpenFoam-Extend sanity check for decomp libaries (`#784 <https://github.com/easybuilders/easybuild-easyblocks/pull/784>`_)
+  * extend OpenFoam-Extend sanity check for decomp libraries (`#784 <https://github.com/easybuilders/easybuild-easyblocks/pull/784>`_)
   * enhance Java easyblock to support installing Java 6.x (`#940 <https://github.com/easybuilders/easybuild-easyblocks/pull/940>`_)
   * make QuantumESPRESSO easyblock aware of multithreaded FFT (`#954 <https://github.com/easybuilders/easybuild-easyblocks/pull/954>`_)
   * extend PSI easyblock to use PCMSolver and CheMPS2 (`#967 <https://github.com/easybuilders/easybuild-easyblocks/pull/967>`_)
@@ -3257,7 +3257,7 @@ feature + bugfix release
   * support overriding # used cores via ``--parallel`` (`#1393 <https://github.com/easybuilders/easybuild-framework/pull/1393>`_)
   * also define ``$FC`` and ``$FCFLAGS`` in build environment (`#1394 <https://github.com/easybuilders/easybuild-framework/pull/1394>`_)
   * add support extracting for ``.tar.Z`` files (`#1396 <https://github.com/easybuilders/easybuild-framework/pull/1396>`_)
-  * include easybuild/scripts in instalation (`#1397 <https://github.com/easybuilders/easybuild-framework/pull/1397>`_)
+  * include easybuild/scripts in installation (`#1397 <https://github.com/easybuilders/easybuild-framework/pull/1397>`_)
   * ignore hidden directories in find_base_dir (`#1413 <https://github.com/easybuilders/easybuild-framework/pull/1413>`_, `#1415 <https://github.com/easybuilders/easybuild-framework/pull/1415>`_)
   * add ``only_if_module_is_available`` decorator function to guard functionality that uses optional dependencies (`#1416 <https://github.com/easybuilders/easybuild-framework/pull/1416>`_)
   * give easyblocks the possibility to choose ``maxhits`` for ``run_cmd_qa`` (`#1417 <https://github.com/easybuilders/easybuild-framework/pull/1417>`_)
@@ -3528,7 +3528,7 @@ feature + bugfix release
   * stop making ``ModulesTool`` class a singleton since it causes problems when multilple toolchains are in play (`#1299 <https://github.com/easybuilders/easybuild-framework/pull/1299>`_)
   * don't modify values of 'paths' list passed as argument to prepend_paths in ``ModuleGenerator`` (`#1300 <https://github.com/easybuilders/easybuild-framework/pull/1300>`_)
   * fix issue with ``EasyConfig.dump()`` + cleanup (`#1308 <https://github.com/easybuilders/easybuild-framework/pull/1308>`_), `#1311 <https://github.com/easybuilders/easybuild-framework/pull/1311>`_)
-  * reenable (and fix) accidentally disabled test (`#1316 <https://github.com/easybuilders/easybuild-framework/pull/1316>`_)
+  * re-enable (and fix) accidentally disabled test (`#1316 <https://github.com/easybuilders/easybuild-framework/pull/1316>`_)
 
 **easyblocks**
 
@@ -3778,7 +3778,7 @@ feature + bugfix release
 
 * various bug fixes, including:
 
-  * fix Score-P easyblock for compiler-only toolchains, include Qt as optional dependecy (`#552 <https://github.com/easybuilders/easybuild-easyblocks/pull/552>`_)
+  * fix Score-P easyblock for compiler-only toolchains, include Qt as optional dependency (`#552 <https://github.com/easybuilders/easybuild-easyblocks/pull/552>`_)
   * fix definition of ``$MKLROOT``, should be set to '``mkl``' subdir of install dir (`#576 <https://github.com/easybuilders/easybuild-easyblocks/pull/576>`_)
   * add ``-libmpichf90`` to list of MPI libraries in NWChem easyblock (`#584 <https://github.com/easybuilders/easybuild-easyblocks/pull/584>`_)
   * stop using '``$root``' to make easyblocks compatible with module files in Lua syntax (`#590 <https://github.com/easybuilders/easybuild-easyblocks/pull/590>`_)
@@ -4353,7 +4353,7 @@ feature + bugfix release
     * example: ``GCC/4.7.2`` in ``Core`` subdir, ``OpenMPI/1.6.5`` in ``Compiler/GCC/4.7.2`` subdir
 
   * make ``ModuleNamingScheme`` class a singleton, move it into ``easybuild.tools.module_naming_scheme.mns`` module
-  * implement ``ActiveMNS`` wrapper class for quering active module naming scheme
+  * implement ``ActiveMNS`` wrapper class for querying active module naming scheme
   * implement toolchain inspection functions that can be used in a custom module naming scheme
 
     * ``det_toolchain_compilers``, ``det_toolchain_mpi`` in ``easybuild.tools.module_naming_scheme.toolchain``
@@ -4371,7 +4371,7 @@ feature + bugfix release
 
   * added toolchain definitions for 'common' toolchains: ``intel`` and ``foss`` (`#956 <https://github.com/easybuilders/easybuild-framework/pull/956>`_)
   * implement caching for easyconfig files, parsed easyconfigs and toolchains (`#953 <https://github.com/easybuilders/easybuild-framework/pull/953>`_)
-  * enable ``--ignore-osdeps`` implicitely when ``-D``, ``--dry-run`` or ``--dep-graph`` are used (`#953 <https://github.com/easybuilders/easybuild-framework/pull/953>`_)
+  * enable ``--ignore-osdeps`` implicitly when ``-D``, ``--dry-run`` or ``--dep-graph`` are used (`#953 <https://github.com/easybuilders/easybuild-framework/pull/953>`_)
   * flesh out ``use_group`` and ``det_parallelism`` function, include them in ``easybuild.tools.systemtools`` (`#953 <https://github.com/easybuilders/easybuild-framework/pull/953>`_)
   * make symlinking of module files part of module naming scheme API (`#973 <https://github.com/easybuilders/easybuild-framework/pull/973>`_)
 
@@ -4830,7 +4830,7 @@ feature + bugfix release
 * various bug fixes:
 
   * use unwanted env var functionality to unset ``$MKLROOT`` rather than failing with an error (`#273 <https://github.com/easybuilders/easybuild-easyblocks/pull/273>`_)
-  * always include ``-w`` flag for preprocessor to supress warnings that may break QuantumESPRESSO configure (`#317 <https://github.com/easybuilders/easybuild-easyblocks/pull/317>`_)
+  * always include ``-w`` flag for preprocessor to suppress warnings that may break QuantumESPRESSO configure (`#317 <https://github.com/easybuilders/easybuild-easyblocks/pull/317>`_)
   * link with multithreaded LAPACK libs for ESMF (`#319 <https://github.com/easybuilders/easybuild-easyblocks/pull/319>`_)
   * extend ``noqanda`` list of patterns in CUDA easyblock (`#328 <https://github.com/easybuilders/easybuild-easyblocks/pull/328>`_, `#337 <https://github.com/easybuilders/easybuild-easyblocks/pull/337>`_)
   * add ``import _ctypes`` to Python sanity check commands to capture a common build issue (`#329 <https://github.com/easybuilders/easybuild-easyblocks/pull/329>`_)
@@ -5238,7 +5238,7 @@ feature + bugfix release
 * various bug fixes, including:
 
   * add salt to temporary log file name (`#656 <https://github.com/easybuilders/easybuild-framework/pull/656>`_, `#665 <https://github.com/easybuilders/easybuild-framework/pull/665>`_)
-  * fix determining CPU architecture on Rasberry Pi (ARM) systems (`#655 <https://github.com/easybuilders/easybuild-framework/pull/655>`_, `#662 <https://github.com/easybuilders/easybuild-framework/pull/662>`_)
+  * fix determining CPU architecture on Raspberry Pi (ARM) systems (`#655 <https://github.com/easybuilders/easybuild-framework/pull/655>`_, `#662 <https://github.com/easybuilders/easybuild-framework/pull/662>`_)
   * fix support for determining base path of tarballs containing a single file (`#660 <https://github.com/easybuilders/easybuild-framework/pull/660>`_)
 
 **easyblocks**
@@ -5572,7 +5572,7 @@ feature + bugfix release
 
     * ``--enable-mpi-thread-multiple`` instead of ``--enable-mpi-threads``
 
-  * explicitely add ``--without-openib --without-udapl`` configure options in OpenMPI easyconfig using versionsuffix ``-no-OFED`` (`#168 <https://github.com/easybuilders/easybuild-easyconfigs/pull/168>`_)
+  * explicitly add ``--without-openib --without-udapl`` configure options in OpenMPI easyconfig using versionsuffix ``-no-OFED`` (`#168 <https://github.com/easybuilders/easybuild-easyconfigs/pull/168>`_)
 
     * this avoids that OpenMPI auto-detects that it can enable Infiniband (OpenIB) support, which doesn't fit the -no-OFED versionsuffix
     * Note: this makes goalf-1.1.0-no-OFED effectively not suitable to produce software builds that are IB-capable!

--- a/docs/Removed-functionality.rst
+++ b/docs/Removed-functionality.rst
@@ -350,7 +350,7 @@ Module path of default class for extensions
 * *removed in:* EasyBuild v2.0
 * *alternative(s)*: *(none required, module path is derived from specified class name)*
 
-Explicitely specifying the module path for the default class to use for extensions (via ``exts_defaultclass``) is
+Explicitly specifying the module path for the default class to use for extensions (via ``exts_defaultclass``) is
 no longer possible. Only the class name should be specified, the corresponding module path is derived from it.
 
 Module path for easyblocks
@@ -385,7 +385,7 @@ alternative module naming schemes:
 
 * the ``modules`` class variable and the ``add_module``/``remove_module`` methods are removed; modules should be
   (un)loaded using the ``load`` and ``unload`` methods instead
-* the ``mod_paths`` and ``modulePath`` named arguments for the ``run_module`` method aare removed; the class instance
+* the ``mod_paths`` and ``modulePath`` named arguments for the ``run_module`` method are removed; the class instance
   should be created with a specific list of module paths instead
 * the ``Modules`` class to obtain a class instance representing a modules tool interface is removed;
   the ``modules_tool`` function should be used instead

--- a/docs/Submitting_jobs.rst
+++ b/docs/Submitting_jobs.rst
@@ -227,8 +227,8 @@ When using GC3Pie as a job backend, a configuration file must be provided via ``
 This section includes a couple of examples of GC3Pie configuration files (see also
 https://gc3pie.readthedocs.org/en/latest/users/configuration.html).
 
-Example GC3Pie configuraton for local system
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Example GC3Pie configuration for local system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: ini
 

--- a/docs/Unit-tests.rst
+++ b/docs/Unit-tests.rst
@@ -149,7 +149,7 @@ instead. Thus, to set a particular configuration option ``--foo``, you should de
 Modules tool to use for running tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-One particular configuration option worth mentioning explicitely is the modules tool that is to be used by the EasyBuild
+One particular configuration option worth mentioning explicitly is the modules tool that is to be used by the EasyBuild
 framework, which is by default the traditional Tcl/C environment modules, referred to as ``EnvironmentModulesC`` in
 EasyBuild configuration terms (see ``eb --help`` and ``eb --avail-modules-tools``).
 

--- a/docs/Using_external_modules.rst
+++ b/docs/Using_external_modules.rst
@@ -93,7 +93,7 @@ The following keys are supported:
 * ``version``: specifies the software version(s) that is (are) provided by the module
 * ``prefix``: specifies the installation prefix of the software that is provided by the module
 
-For ``prefix``, a couple of different options are avaialble, i.e.:
+For ``prefix``, a couple of different options are available, i.e.:
 
 * specifying an absolute path (cfr. ``cray-hdf5-parallel/1.8.13`` in the example above)
 * specifying the environment variable that is defined by the module and provides the installation prefix

--- a/docs/Using_the_EasyBuild_command_line.rst
+++ b/docs/Using_the_EasyBuild_command_line.rst
@@ -23,7 +23,7 @@ This can be done in a number of ways:
 * :ref:`specifying_easyconfigs_set_of_easyconfigs`
 * :ref:`from_pr`
 
-Whenever EasyBuild searches for *explicitely specified* easyconfig files, it considers a couple of locations, i.e. (in order of preference):
+Whenever EasyBuild searches for *explicitly specified* easyconfig files, it considers a couple of locations, i.e. (in order of preference):
 
 (i)   the local working directory
 (ii)  the robot search path (see :ref:`robot_search_path`)
@@ -36,7 +36,7 @@ These locations are only considered for easyconfig files that are specified only
 .. note::
   For easyconfig files specified on the ``eb`` command line, the *full* robot search path is only considered since
   EasyBuild v2.0.0. Earlier versions only considered the local working directory and the easyconfig files that are
-  part of the active EasyBuild installation for *explicitely specified* easyconfig files.
+  part of the active EasyBuild installation for *explicitly specified* easyconfig files.
 
 .. _specifying_easyconfigs_single:
 

--- a/docs/Writing_yeb_easyconfig_files.rst
+++ b/docs/Writing_yeb_easyconfig_files.rst
@@ -433,7 +433,7 @@ Easyconfig file in YAML syntax for the goolf v1.4.10 toolchain.
 
     # compiler toolchain dependencies
     # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
-    # because of toolchain preperation functions
+    # because of toolchain preparation functions
         dependencies:
             - *comp_name: *comp_version
             - OpenMPI: 1.6.4

--- a/docs/demos/scripts/configuring.script
+++ b/docs/demos/scripts/configuring.script
@@ -68,7 +68,7 @@ eb --show-config
 ### - $HOME/.local/easybuild is the default value for the 'prefix' configuration option
 ###
 ### - the 'buildpath', 'installpath', 'repositorypath', and 'sourcepath' configuration options are derived from 'prefix',
-###   unless they were specified explicitely
+###   unless they were specified explicitly
 ###
 ### - by default, the 'robot-paths' configuration option includes the path to the easyconfig files included in the EasyBuild installation
 

--- a/docs/version-specific/generic_easyblocks.rst
+++ b/docs/version-specific/generic_easyblocks.rst
@@ -233,7 +233,7 @@ Build a Python package and module with cmake.
     Some packages use cmake to first build and install C Python packages
     and then put the Python package in lib/pythonX.Y/site-packages.
 
-    We install this in a seperate location and generate a module file 
+    We install this in a separate location and generate a module file 
     which sets the PYTHONPATH.
 
     We use the default CMake implementation, and use make_module_extra from PythonPackage.


### PR DESCRIPTION
Use the codespell python package to spell check the docs, see https://github.com/codespell-project/codespell for details.

I didn't clean `Supported_software.rst` since that is dynamically generated (I think).