### PR TITLE
fix broken reference in documentation page on container support

### DIFF
--- a/docs/Containers.rst
+++ b/docs/Containers.rst
@@ -30,7 +30,7 @@ Requirements
 ------------
 
 * Docker, or Singularity version 2.4 (or more recent, incl. version 3.x)
-* ``sudo`` permissions *(only required to actually build container images, see :ref:`containers_usage_build_image`)*
+* ``sudo`` permissions *(only required to actually build container images, see* :ref:`containers_usage_build_image` *)*
 
 
 .. _containers_usage:


### PR DESCRIPTION
fixes broken link in https://easybuild.readthedocs.io/en/latest/Containers.html#requirements

Reference was broken because it was enclosed in `*...*` (italics) :-/

reported by @geimer