### PR TITLE
doc updates for EasyBuild v4.1.0

### DIFF
--- a/docs/Backup_modules.rst
+++ b/docs/Backup_modules.rst
@@ -11,11 +11,11 @@ Backing up of existing modules can be enabled with ``--backup-modules``.
 Backups are stored in the same directory as where the module file was located,
 and the files are given an additional extension of the form ``.bak_<year><month><day><hour><min><sec>``.
 
-* With module files in Tcl syntax, the backup module file is hidden by adding a leading dot to the filename; 
+* With module files in Tcl syntax, the backup module file is hidden by adding a leading dot to the filename;
   this is done to avoid that it is displayed as a normal module in ``module avail``.
-* With module files in Lua syntax, the backup module file is not made hidden since the additional
-  ``.bak_*`` extension prevents Lmod from picking it up as a valid module file (only files ending in ``.lua``
-  are considered to be module files)
+* With module files in Lua syntax, the backup module file is not made hidden (unless Lmod 6.x is used),
+  since the additional ``.bak_*`` extension prevents from picking it up as a valid module file;
+  only files ending in ``.lua`` are considered to be module files by Lmod 7+ .
 
 The location of the backed up module file will be printed, as well as a "unified diff" comparison
 (very similar to what ``diff -u`` produces) between the backed up module file and the newly generated module file
@@ -75,7 +75,7 @@ To reinstall the ``bzip2/1.0.6`` module in Lua syntax while retaining a backup o
      setenv("EBDEVELBZIP2", pathJoin(root, "easybuild/bzip2-1.0.6-easybuild-devel"))
 
     ...
-    
+
 Equivalently, we can reinstall the module in Tcl syntax using::
 
     $ eb bzip2-1.0.6.eb --module-syntax=Tcl --force --backup-modules

--- a/docs/Deprecated-functionality.rst
+++ b/docs/Deprecated-functionality.rst
@@ -26,7 +26,8 @@ for which support will be removed in EasyBuild version 5.0.
 
 For EasyBuild users:
 
-*(nothing yet)*
+* :ref:`depr_lmod6`
+* :ref:`depr_python26`
 
 For authors of easyconfig files:
 
@@ -39,6 +40,34 @@ For developers of easyblocks:
 For EasyBuild framework developers:
 
 *(nothing yet)*
+
+.. _depr_lmod6:
+
+Support for using Lmod 6.x
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* *deprecated since:* EasyBuild v4.1.0 (Nov'19)
+* *removed in:* EasyBuild v5.0
+* *alternative(s)*: **use Lmod 7.x or more recent**
+
+Support for using Lmod 6.x as modules tool with EasyBuild has been deprecated,
+and will be removed in a future version of EasyBuild.
+
+
+.. _depr_python26:
+
+Support for running EasyBuild on top of Python 2.6
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* *deprecated since:* EasyBuild v4.1.0 (Nov'19)
+* *removed in:* EasyBuild v5.0
+* *alternative(s)*: **use Python 2.7 or 3.5+**
+
+Support for running EasyBuild on top of Python 2.6 has been deprecated,
+and will be removed in a future version of EasyBuild.
+
+You should upgrade to a newer version of Python (see also :ref:`py2_py3_compatibility`).
+
 
 .. _depr_dummy_toolchain:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ copyright = '2012-2019, Ghent University, CC-BY-SA'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '4.0.1'  # this is meant to reference the version of EasyBuild
+version = '4.1.0.dev'  # this is meant to reference the version of EasyBuild
 # The full version, including alpha/beta/rc tags.
 release = '20191015.0'  # this is meant to reference the version of the documentation itself
 


### PR DESCRIPTION
* tweak docs on backing up of module files w.r.t. https://github.com/easybuilders/easybuild-framework/pull/3089
* document deprecation of support for using Lmod 6.x and Python 2.6 (cfr. https://github.com/easybuilders/easybuild-framework/pull/3077 & https://github.com/easybuilders/easybuild-framework/pull/3076)

previews:
* https://boegel-eb.readthedocs.io/en/docs_update_eb410/Backup_modules.html
* https://boegel-eb.readthedocs.io/en/docs_update_eb410/Deprecated-functionality.html