### PR TITLE
Travis CI: Test for Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - python: "3.8"
 # command to install dependencies
 install:
-  - pip install sphinx codespell
+  - pip install codespell flake8 sphinx
 # command to run tests
 script:
   # it is (currently) impossible to dismiss ignored suggestions but these are
@@ -14,6 +14,7 @@ script:
   # suggestions). Since we know we have one of these, we allow for that.
   # see https://github.com/easybuilders/easybuild/pull/485 for details
   - codespell --skip=".git,version-specific,scripts" --ignore-words-list=atleast,ninjs,simpy,proovread --quiet-level=2; retVal=$?; if [ $retVal -eq 1 ]; then echo "Got one expected warning, so success!";  else $(exit $retVal); fi;
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - READTHEDOCS=1 sphinx-build docs build
   # test installation too (using options that don't require to have a modules tool installed)
   - pip install $TRAVIS_BUILD_DIR


### PR DESCRIPTION
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.