### PR TITLE
add references to more information w.r.t. toolchains + move up link to common toolchains page on landing page

### DIFF
--- a/docs/Common-toolchains.rst
+++ b/docs/Common-toolchains.rst
@@ -224,3 +224,11 @@ To customize a toolchain component, you should copy the corresponding easyconfig
 modify according to your needs, and make sure it is included in a location in the robot search path
 that precedes the location of the easyconfig files that are included with EasyBuild
 (see also :ref:`robot_search_path`), before building and installation the toolchain.
+
+More information about toolchains
+---------------------------------
+
+Please see the :ref:`toolchains_table` for how to obtain a listing of the currently known toolchains.
+
+For a detailed listing of the compiler options available with each toolchain, please see :ref:`avail_toolchain_opts`.
+

--- a/docs/Concepts_and_Terminology.rst
+++ b/docs/Concepts_and_Terminology.rst
@@ -117,6 +117,10 @@ Recent releases of EasyBuild include out-of-the-box toolchain support for:
 - common MPI libraries, such as Intel MPI, MPICH, MVAPICH2, OpenMPI
 - various numerical libraries, including ATLAS, Intel MKL, OpenBLAS, ScalaPACK, FFTW
 
+Please see the :ref:`common_toolchains` page for details about the two most common toolchains,
+one for "free and open source software" (``foss``) based on GCC and one based on the Intel compilers
+(``intel``).
+
 .. _system_toolchain:
 
 ``system`` toolchain

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Getting started
 
     Installation
     Configuration
+    Common-toolchains
 
 
 Basic usage topics
@@ -58,7 +59,6 @@ Advanced usage topics
 
     Archived-easyconfigs
     Backup_modules
-    Common-toolchains
     Containers
     Contributing
     Controlling_compiler_optimization_flags


### PR DESCRIPTION
Per Slack discussion

What do you think of the idea of adding links to these two pages from

https://easybuild.readthedocs.io/en/latest/eb_list_toolchains.html
https://easybuild.readthedocs.io/en/latest/version-specific/toolchain_opts.html

along with some text that they are for more detailed information about toolchains and with a table of contents entry something like "More information about available toolchains"  to this page,

https://easybuild.readthedocs.io/en/latest/Common-toolchains.html

or in the Toolchains section of

https://easybuild.readthedocs.io/en/latest/Concepts_and_Terminology.html#toolchains

I was unable to find links to the two pages with more details via the table of contents, and I think that would help beginners who do not necessarily know the terms well to be able to find them from a section to which they are likely to browse via the ToC.