### PR TITLE
add documentation for --include-easyblocks-from-pr

### DIFF
--- a/docs/Including_additional_Python_modules.rst
+++ b/docs/Including_additional_Python_modules.rst
@@ -85,6 +85,9 @@ Generic easyblocks are expected to be located in a directory named ``generic``.
 To verify that the easyblocks you included are indeed being picked up, ``--list-easyblocks=detailed`` can be used
 (see also :ref:`list_easyblocks`).
 
+Since EasyBuild 4.2.0, easyblocks from a PR can also be included with ``--include-easyblocks-from-pr``,
+see :ref:`github_include_easyblocks_from_pr`
+
 Example
 ~~~~~~~
 

--- a/docs/Including_additional_Python_modules.rst
+++ b/docs/Including_additional_Python_modules.rst
@@ -85,8 +85,8 @@ Generic easyblocks are expected to be located in a directory named ``generic``.
 To verify that the easyblocks you included are indeed being picked up, ``--list-easyblocks=detailed`` can be used
 (see also :ref:`list_easyblocks`).
 
-Since EasyBuild 4.2.0, easyblocks from a PR can also be included with ``--include-easyblocks-from-pr``,
-see :ref:`github_include_easyblocks_from_pr`
+Since EasyBuild 4.2.0, easyblocks from a pull request on GitHub can also be included,
+using ``--include-easyblocks-from-pr`` (see :ref:`github_include_easyblocks_from_pr`).
 
 Example
 ~~~~~~~

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -376,7 +376,7 @@ For example, to use the LAMMPS easyblock contributed via `easyblocks pull reques
 <https://github.com/easybuilders/easybuild-easyblocks/pull/1964>`_ together with the LAMMPS v7Aug2019 easyconfigs contributed via 
 `easyconfigs pull request #9884 <https://github.com/easybuilders/easybuild-easyconfigs/pull/9884>`_::
 
-    $ eb --from-pr 9884 --include-easyblocks 1964 --list-easyblocks=detailed
+    $ eb --from-pr 9884 --include-easyblocks--from-pr 1964 --list-easyblocks=detailed
     == temporary log file in case of crash /tmp/eb-Eq2zsJ/easybuild-1AaWf8.log
     EasyBlock (easybuild.framework.easyblock)
     ...

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -353,6 +353,37 @@ in that same pull request for netCDF, WRF, ...::
 Again, note that locally available easyconfigs that are required to resolve dependencies are being picked up as needed.
 
 
+.. _github_include_easyblocks_from_pr:
+
+Using easyblocks from pull requests (``--include-easyblocks-from-pr``)
+----------------------------------------------------
+
+*(supported since EasyBuild v4.2.0)*
+
+Via the ``--include-easyblocks-from-pr`` command line option (available since EasyBuild v4.2.0), easyblocks that are added or
+modified by a particular pull request to the `easybuild-easyblocks GitHub repository
+<https://github.com/easybuilders/easybuild-easyblocks>`_ can be used (regardless of whether the pull request is merged
+or not).
+
+This can be useful to employ easyblocks that are not available yet in the active EasyBuild installation,
+or to test new contributions by combining ``--include-easyblocks-from-pr`` with ``--from-pr`` and ``--upload-test-report``
+(see :ref:`github_upload_test_report`).
+
+When ``--include-easyblocks-from-pr`` is used, EasyBuild will download all modified easyblocks to a temporary
+directory before processing them.
+
+For example, to use the LAMMPS easyblock contributed via `easyblocks pull request #1964 
+<https://github.com/easybuilders/easybuild-easyblocks/pull/1964>`_ together with the LAMMPS v7Aug2019 easyconfigs contributed via 
+`easyconfigs pull request #9884 <https://github.com/easybuilders/easybuild-easyconfigs/pull/9884>`_::
+
+    $ eb --from-pr 9884 --include-easyblocks 1964 --list-easyblocks=detailed
+    == temporary log file in case of crash /tmp/eb-Eq2zsJ/easybuild-1AaWf8.log
+    EasyBlock (easybuild.framework.easyblock)
+    ...
+    |   |   |-- EB_LAMMPS (easybuild.easyblocks.lammps @ /tmp/included-easyblocks-rD2HEQ/easybuild/easyblocks/lammps.py)
+    ...
+
+
 .. _github_upload_test_report:
 
 Uploading test reports (``--upload-test-report``)

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -360,7 +360,7 @@ Using easyblocks from pull requests (``--include-easyblocks-from-pr``)
 
 *(supported since EasyBuild v4.2.0)*
 
-Via the ``--include-easyblocks-from-pr`` command line option (available since EasyBuild v4.2.0), easyblocks that are added or
+Via the ``--include-easyblocks-from-pr`` command line option, easyblocks that are added or
 modified by a particular pull request to the `easybuild-easyblocks GitHub repository
 <https://github.com/easybuilders/easybuild-easyblocks>`_ can be used (regardless of whether the pull request is merged
 or not).
@@ -370,7 +370,8 @@ or to test new contributions by combining ``--include-easyblocks-from-pr`` with 
 (see :ref:`github_upload_test_report`).
 
 When ``--include-easyblocks-from-pr`` is used, EasyBuild will download all modified easyblocks to a temporary
-directory before processing them.
+directory before processing them. Just like with ``--include-easyblocks`` (see :ref:`include_easyblocks`),
+the easyblocks that are included are preferred over the ones included in the EasyBuild installation.
 
 For example, to use the LAMMPS easyblock contributed via `easyblocks pull request #1964 
 <https://github.com/easybuilders/easybuild-easyblocks/pull/1964>`_ together with the LAMMPS v7Aug2019 easyconfigs contributed via 


### PR DESCRIPTION
requires https://github.com/easybuilders/easybuild-framework/pull/3206

preview at https://mdc-easybuild.readthedocs.io/en/include_easyblocks_from_pr/Integration_with_GitHub.html#using-easyblocks-from-pull-requests-include-easyblocks-from-pr