### PR TITLE
Clarify recent self.cfg and extensions documentation

### DIFF
--- a/docs/Implementing-easyblocks.rst
+++ b/docs/Implementing-easyblocks.rst
@@ -274,23 +274,23 @@ then these three parameters are accessible within an easyblock via
 
   longform = ''.join(self.cfg['name'],'/',self.cfg['version'],self.cfg['versionsuffix'])
 
-You can use this notation successfully in your easyblock.  For all of the variables listed
-:ref:`vsd_avail_easyconfig_params`, the ``EasyBlock`` base class copies those dictionary entries into local Python
-variables:
+You can use this notation successfully in your easyblock.  A few of the most commonly used parameters can be referenced
+directly,
 
-* ``self.name = self.cfg['name']``
-* ``self.version = self.cfg['version']``
-* ``self.versionsuffix = self.cfg['versionsuffix']``
+* **self.name** = ``self.cfg['name']``
+* **self.version** = ``self.cfg['version']``
+* **self.toolchain** = ``self.cfg['toolchain']``
+* **self.all_dependencies**: combines ``builddependencies``, ``dependencies``, and ``toolchain``, in one dictionary
 
-and so on.  So in your easyblock code, you may replace the above expression
-with
+So in your easyblock code, you may replace the above expression with
 
 .. code:: python
 
-  longform = ''.join(self.name,'/',self.version,self.versionsuffix)
+  longform = ''.join(self.name,'/',self.version,self.cfg['versionsuffix'])
 
-Any additional :ref:`custom parameters <implementing_easyblocks_custom_parameters>` which you define for your own
-easyblock, will not be automatically mapped.  You will need to use ``self.cfg`` to access them in your code.
+The other easyconfig parameters, and any additional :ref:`custom parameters
+<implementing_easyblocks_custom_parameters>` which you define for your own easyblock, will not be automatically mapped.
+You will need to use ``self.cfg`` to access them in your code.
 
 
 .. _implementing_easyblocks_custom_parameters:

--- a/docs/Writing_easyconfig_files.rst
+++ b/docs/Writing_easyconfig_files.rst
@@ -518,11 +518,11 @@ Since EasyBuild v2.1, specifying modules that are not provided via EasyBuild as 
 See :ref:`using_external_modules` for more information.
 
 
-Module Extensions
-~~~~~~~~~~~~~~~~~
+Extensions
+~~~~~~~~~~
 
-Besides dependencies, which are found outside the module being built but are part of the site's EasyBuild installation,
-it is also possible to incorporate extensions to the module within the build.  This is done via the ``exts_list`` array.
+Besides dependencies, which are found outside the software being built but are part of the site's EasyBuild installation,
+it is also possible to incorporate extensions to the software within the build.  This is done via the ``exts_list`` array.
 
 Each entry in ``exts_list`` is a three-component tuple, with the name and
 version number, and a dictionary of configuration options for the entry:


### PR DESCRIPTION
Explicitly list easyblock 'properties' (which look like data member names) which reference `self.cfg` dictionary entries, and how to use them.  Don't use 'module' qualifier for extensions.

See https://github.com/easybuilders/easybuild/pull/617/files#r449669160