### PR TITLE
refer to GitHub Actions rather than Travis w.r.t. CI tests

### DIFF
--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -448,7 +448,7 @@ Updating existing pull requests
           Please consider using ``eb --update-pr`` instead, see :ref:`github_update_pr`.
 
 It is quite common to update a pull request after creating it,
-for example if Travis reports problems with the changes being made, or as a response
+for example if the test suite run in GitHub Actions reports problems with the changes being made, or as a response
 to someone reviewing your contribution.
 
 To update an existing pull request, it suffices to add commits to the branch
@@ -464,7 +464,7 @@ For example, to update the pull request that was created using the ``mybranch`` 
   git commit -m "example commit message for additional changes"
   git push origin mybranch
 
-Updating a pull request will trigger Travis to re-test your contribution,
+Updating a pull request will trigger GitHub Actions to re-test your contribution,
 and a notification will be sent out to whoever is 'watching' your pull request.
 
 
@@ -473,7 +473,7 @@ and a notification will be sent out to whoever is 'watching' your pull request.
 Merging of pull requests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once your pull request has been given the green light by Travis and one or more
+Once your pull request has been given the green light by GitHub Actions and one or more
 people reviewing have approved the changes, it can be merged into
 the ``develop`` branch.
 
@@ -501,7 +501,7 @@ Requirements for pull requests
 
 (i) *the PR must target the* ``develop`` *branch of the repository*; see :ref:`contributing_review_process_develop_branch`
 
-(ii) *the test suite must (still) pass*, i.e. Travis *must* give a green light; see :ref:`contributing_review_process_travis`
+(ii) *the test suite must (still) pass*, i.e. GitHub Actions *must* give a green light; see :ref:`contributing_review_process_travis`
 
   * *tests should be added or enhanced when appropriate*; see :ref:`contributing_review_process_adding_tests`,
     especially for PRs to the ``easybuild-framework`` repository
@@ -532,17 +532,18 @@ when preparing a new EasyBuild release.
 Occasionally, an additional version branch (e.g. '``3.3.x``') may be introduced temporarily,
 in case an intermittent bugfix release is being worked on.
 
-.. _contributing_review_process_travis:
+.. _contributing_review_process_github_actions:
 
-Test suite (Travis)
-~~~~~~~~~~~~~~~~~~~
+Test suite (GitHub Actions)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each pull request is tested automatically by Travis and the test result is reported in the pull request.
+Each pull request is tested automatically by `GitHub Actions <https://github.com/features/actions>`_
+and the test result is reported in the pull request.
 
-**Only pull requests that have been tested and approved by Travis are
+**Only pull requests that have been tested and approved by GitHub Actions are
 eligible for being merged!**
 
-Note that Travis will only run the *test suite* for that particular repository.
+Note that GitHub Actions will only run the *test suite* for that particular repository.
 That is, for easyconfig contributions it does *not* include
 actually building and installing software.
 
@@ -612,7 +613,7 @@ be contributed can be performed via ``eb --check-contrib``. This will check:
 * style aspects for the specified easyconfig files
 * whether SHA256 checksums are included for all source files & patches
 
-This check is also a part of the test suite run by Travis for easyconfig PRs.
+This check is also a part of the test suite run by GitHub Actions for easyconfig PRs.
 
 
 .. _contributing_review_process_review_pr:

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -238,7 +238,7 @@ for pull requests based on an outdated branch in which easyconfigs are changed t
 as well.
 
 As such, the exact semantics of ``--from-pr`` depends on the state of the specified pull request, i.e. whether or not
-the pull request was merged already, whether the pull request is mergeable and stable (as indicated by Travis), etc.
+the pull request was merged already, whether the pull request is mergeable and stable (as indicated by GitHub Actions), etc.
 
 .. _github_from_pr_vs_develop_open_stable_prs:
 
@@ -279,7 +279,7 @@ For closed and unstable pull requests, only the branch corresponding to the pull
 which aligns with the semantics of ``--from-pr`` as it was before EasyBuild v2.9.0. In this case, the current
 ``develop`` branch is *not* taken into account.
 
-.. note:: A pull request is considered unstable when GitHub reports merge conflicts or when Travis reports
+.. note:: A pull request is considered unstable when GitHub reports merge conflicts or when GitHub Actions reports
           one or more failing tests.
 
 


### PR DESCRIPTION
We're slowly moving away from Travis, switching over to GitHub Actions (see https://github.com/easybuilders/easybuild-easyconfigs/pull/11055), so let's reflect that in the docs...