### PR TITLE
Fix broken create index command

### DIFF
--- a/docs/Easyconfigs_index.rst
+++ b/docs/Easyconfigs_index.rst
@@ -137,7 +137,7 @@ By default, EasyBuild will consider index files to remain valid for 1 week (7 * 
 
 To create an index that *always* remains valid (never expires), use zero (``0``) as value for ``--index-max-age``::
 
-  $ eb --create-index --index-max-age=0 $HOME/easybuild-easyconfigs/easybuild/easyconfigs
+  $ eb --index-max-age=0 --create-index $HOME/easybuild-easyconfigs/easybuild/easyconfigs
 
   $ head -n 2 $HOME/easybuild-easyconfigs/easybuild/easyconfigs/.eb-path-index
   # created at: 2020-04-13 15:10:07.173191


### PR DESCRIPTION
I tried to run the following example from this page, but it didn't work:

```
$ eb --create-index --index-max-age=0 $HOME/easybuild/cit-hpc-easybuild/easyconfigs
Usage: eb [options] easyconfig [...]

eb: error: Value '--index-max-age=0' starts with a '-'. Use '--create-index=--index-max-age=0' if the value is correct.
```

This does work:
```
$ eb --index-max-age=0 --create-index $HOME/easybuild/cit-hpc-easybuild/easyconfigs
```

And, according to `eb --help`, it should in principle even be `--create-index=$HOME/easybuild/cit-hpc-easybuild/easyconfigs` (in that case, more commands on this page should be fixed)?