### PR TITLE
Prevent wrong dash appearing in doc

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -522,7 +522,7 @@ Some dependencies are optional and are only required to support certain features
 Optional Python packages
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* `GC3Pie <https://pypi.org/project/gc3pie>`_, only needed when using `GC3Pie` as a backend for `--job`,
+* `GC3Pie <https://pypi.org/project/gc3pie>`_, only needed when using `GC3Pie` as a backend for ``--job``,
   see also :ref:`submitting_jobs`;
 * `GitPython <http://gitorious.org/git-python>`_, only needed if
   EasyBuild is hosted in a git repository or if you’re using a git

--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -637,7 +637,7 @@ has been created. EasyBuild does *not* make changes to an existing working copy 
 (cfr. :ref:`github_git_working_dirs_path`).
 
 .. note:: When modifying existing files via ``--new-pr``,
-          you *must* specify a (meaningful) commit message using `--pr-commit-msg`, see :ref:`github_controlling_pr_metadata`.
+          you *must* specify a (meaningful) commit message using ``--pr-commit-msg``, see :ref:`github_controlling_pr_metadata`.
 
 Example
 +++++++

--- a/docs/Using_the_EasyBuild_command_line.rst
+++ b/docs/Using_the_EasyBuild_command_line.rst
@@ -591,7 +591,7 @@ Tweaking existing easyconfig files, using ``--try-*``
 Making minor changes to existing easyconfig files can be done straight from the ``eb`` command line.
 This way, having to manually copying and editing easyconfig files can be avoided.
 
-Tweaking existing easyconfig files can be done using the **``--try-``*** command line options.
+Tweaking existing easyconfig files can be done using the ``--try-*`` command line options.
 For each of the software build options that can be used as an alternative to specifying easyconfig file names,
 a matching ``--try-X`` command line options is available:
 

--- a/docs/Using_the_EasyBuild_command_line.rst
+++ b/docs/Using_the_EasyBuild_command_line.rst
@@ -591,7 +591,7 @@ Tweaking existing easyconfig files, using ``--try-*``
 Making minor changes to existing easyconfig files can be done straight from the ``eb`` command line.
 This way, having to manually copying and editing easyconfig files can be avoided.
 
-Tweaking existing easyconfig files can be done using the **--try-*** command line options.
+Tweaking existing easyconfig files can be done using the **``--try-``*** command line options.
 For each of the software build options that can be used as an alternative to specifying easyconfig file names,
 a matching ``--try-X`` command line options is available:
 


### PR DESCRIPTION
The previous becomes `–pr-commit-msg`. This makes it `--pr-commit-msg` and similarly for the other two.