### PR TITLE
Adding conditional symlinking of lua posix lib in GH workflow script

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
-        # needed for 18.04 not for 20.04.  Conditional added to skip if posix.so exists
+        # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
         if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
             sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
         fi

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -21,7 +21,10 @@ jobs:
       run: |
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
-        sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        # needed for 18.04 not for 20.04.  Conditional added to skip if posix.so exists
+        if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
+            sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        fi
         # use script provided by easybuild-framework to install recent Lmod
         source install_eb_dep.sh Lmod-8.3.8 $HOME
         echo $MOD_INIT > $HOME/mod_init


### PR DESCRIPTION
The Ubuntu 20 that GitHub has started using has the `lua/5.2/posix.so` file (or link) in it already, so the script that creates it unconditionally for Ubuntu 18 fails because it exists.

Wrapped the `ln` command in an if so that it only tried to create the symlink if the target does not exist.