### PR TITLE
Minimal scope for GitHub token

### DIFF
--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -103,7 +103,7 @@ To obtain a GitHub token:
 
 * visit https://github.com/settings/tokens/new and log in with your GitHub account
 * enter a token description, for example: "``EasyBuild``"
-* make sure (only) the ``gist`` and ``repo`` scopes are fully enabled
+* make sure (only) the ``gist`` and ``public_repo`` (in the ``repo`` section) scopes are fully enabled
 * click ``Generate token``
 * *copy-paste* the generated token
 


### PR DESCRIPTION
While regenerating my GitHub token (due to the recent changes) I looked at the [scopes](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) we've documented as needed. I am fairly sure that we only require:

* `public_repo` (to be able to read/write from the fork of the EB repo)
* `gist` (to create/delete gists)

The first of these reduces from the whole `repo` section to just one item.