### PR TITLE
Change unified diff command

### DIFF
--- a/docs/Writing_easyconfig_files.rst
+++ b/docs/Writing_easyconfig_files.rst
@@ -125,7 +125,7 @@ Remarks:
   is used for downloading (since EasyBuild v2.0)
 * patches need to be EasyBuild-compatible
 
-  * unified diff format (``diff -ru``)
+  * unified diff format (``diff -ruN``)
   * patched locations relative to unpacked sources
 
 * see :ref:`common_easyconfig_param_sources_checksums` for more information on ``checksums``


### PR DESCRIPTION
Puzzled over this one for a while when following the current instructions (not being familiar with using diff and patch). 

If a patch requires removal of a file, removing the file + running 'diff -ru' is not sufficient - you need to also add the N flag to get it to treat the removed file as empty which makes it be removed when patch is called.