### PR TITLE
Update Installing-Lmod-without-root-permissions.rst

### DIFF
--- a/docs/Installing-Lmod-without-root-permissions.rst
+++ b/docs/Installing-Lmod-without-root-permissions.rst
@@ -51,7 +51,7 @@ unexpected ``readline`` or ``ncurses`` libraries:
 Lmod
 ~~~~
 
-Dependencies: building Lmod using the steps below requires tcl, tcl-dev(el) make and bzip2
+Dependencies: building Lmod using the steps below requires tcl, tcl-dev(el), make and bzip2
 
 **Step 1**: Download and unpack the latest available Lmod version,
 `Lmod-8.4.tar.bz2`_ at the time of writing.

--- a/docs/Installing-Lmod-without-root-permissions.rst
+++ b/docs/Installing-Lmod-without-root-permissions.rst
@@ -6,6 +6,7 @@ Installing Lmod without root permissions
 
 This short guide will show how to install Lmod (and Lua, on which it
 depends) on Linux, without requiring root permissions.
+Installing lua using the steps below does require rsync, make and gcc
 
 Lua
 ~~~
@@ -50,12 +51,14 @@ unexpected ``readline`` or ``ncurses`` libraries:
 Lmod
 ~~~~
 
+Dependencies: building Lmod using the steps below requires tcl, tcl-dev(el) make and bzip2
+
 **Step 1**: Download and unpack the latest available Lmod version,
-`Lmod-6.1.tar.bz2`_ at the time of writing.
+`Lmod-8.4.tar.bz2`_ at the time of writing.
 
 .. code:: bash
 
-    tar xfvj Lmod-6.1.tar.bz2 && cd Lmod-6.1
+    tar xfvj Lmod-8.4.tar.bz2 && cd Lmod-8.4
 
 **Step 2**: Configure, build and install Lmod build, in a custom prefix:
 
@@ -68,7 +71,7 @@ Lmod
 
 .. code:: bash
 
-    export PATH=$HOME/lmod/6.1/libexec:$PATH
+    export PATH=$HOME/lmod/8.4/libexec:$PATH
 
 Optionally, give it a spin:
 
@@ -76,7 +79,7 @@ Optionally, give it a spin:
 
     $ lmod --version
 
-    Modules based on Lua: Version 6.1  2016-02-05 16:31
+    Modules based on Lua: Version 8.4  2020-07-31 12:25 -05:00
         by Robert McLay mclay@tacc.utexas.edu
 
 **Step 4**: Define ``module`` function to use ``lmod`` (optional for use
@@ -84,10 +87,10 @@ with EasyBuild):
 
 .. code:: bash
 
-    source $HOME/lmod/6.1/init/bash
-    export LMOD_CMD=$HOME/lmod/6.1/libexec/lmod
+    source $HOME/lmod/8.4/init/bash
+    export LMOD_CMD=$HOME/lmod/8.4/libexec/lmod
 
 .. _`http://sourceforge.net/projects/lmod/files/`: http://sourceforge.net/projects/lmod/files/
-.. _lua-5.1.4.8.tar.gz: http://sourceforge.net/projects/lmod/files/lua-5.1.4.8.tar.gz/download
-.. _Lmod-6.1.tar.bz2: http://sourceforge.net/projects/lmod/files/Lmod-6.1.tar.bz2/download
+.. _lua-5.1.4.8.tar.gz: https://sourceforge.net/projects/lmod/files/lua-5.1.4.8.tar.gz/download
+.. _Lmod-8.4.tar.bz2: https://sourceforge.net/projects/lmod/files/Lmod-8.4.tar.bz2/download
 

--- a/docs/Installing-Lmod-without-root-permissions.rst
+++ b/docs/Installing-Lmod-without-root-permissions.rst
@@ -6,10 +6,11 @@ Installing Lmod without root permissions
 
 This short guide will show how to install Lmod (and Lua, on which it
 depends) on Linux, without requiring root permissions.
-Installing lua using the steps below does require rsync, make and gcc
 
 Lua
 ~~~
+
+Dependencies: Installing Lua using the steps below requires rsync, make and gcc
 
 Build and install Lua using the source tarball available in the Lmod
 SourceForge repository (`http://sourceforge.net/projects/lmod/files/`_).


### PR DESCRIPTION
updated instructions to work for lmod 8.4

bumped because the current instructions don't work for bootstrap:

`easybuild.tools.build_log.EasyBuildError: 'EasyBuild requires Lmod >= v6.5.1, found v6.1`