### PR TITLE
Fix doku about Github tokens

### DIFF
--- a/docs/Integration_with_GitHub.rst
+++ b/docs/Integration_with_GitHub.rst
@@ -93,11 +93,11 @@ Installing a GitHub token (``--install-github-token``)
 
 .. note:: *requires*: GitHub username + ``keyring`` Python package
 
-A GitHub token is a string of 40 hexadecimal (lowercase) characters that is tied to your GitHub account,
+A GitHub token is a string of 40 characters that is tied to your GitHub account,
 allowing you to access the GitHub API authenticated.
 
 Using a GitHub token is beneficial with respect to rate limitations, and enables write permissions on GitHub
-(e.g., posting comments, creating gists, opening pull requests, etc.).
+(e.g. posting comments, creating gists, opening pull requests).
 
 To obtain a GitHub token:
 


### PR DESCRIPTION
Github changed its token format to be Base64 encoded now. They start with `ghp_` and end with a 6-byte checksum after a 30 "digits" of data. See https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

I simplified the description so it applies to new and old tokens and fixed some superflous parts below ("e.g." + "etc")