### PR TITLE
git_config tag option is for getting a tag

### DIFF
--- a/docs/Writing_easyconfig_files.rst
+++ b/docs/Writing_easyconfig_files.rst
@@ -469,7 +469,7 @@ will be created from the cloned repository).
 
 In addition, either of the following keys *must* also be defined:
 
-* ``tag``: the specific tag to download (could be a branch name or an actual tag)
+* ``tag``: the specific tag to download
 * ``commit``: the specific commit ID to download
 
 If a recursive checkout should be made of the repository, the ``recursive`` key can be set to ``True``.


### PR DESCRIPTION
In https://github.com/easybuilders/easybuild-framework/pull/3795 we changed to not allowing the git download method to get a branch, as this causes issues when we there are branchs and tags with the same name.