### PR TITLE
update documentation to use `SYSTEM` template constant for system-toolchain dependencies

### DIFF
--- a/docs/Wrapping_dependencies.rst
+++ b/docs/Wrapping_dependencies.rst
@@ -27,7 +27,7 @@ depending on a specific version (e.g., ``Java/1.8.0_181``):
 .. code::
 
   # specify dependency on Java/1.8 "wrapper", rather than a specific Java version
-  dependencies = [('Java', '1.8', '', True)]
+  dependencies = [('Java', '1.8', '', SYSTEM)]
 
 This has a couple of advantages:
 

--- a/docs/Writing_easyconfig_files.rst
+++ b/docs/Writing_easyconfig_files.rst
@@ -579,16 +579,12 @@ versions prior to v4.0, see :ref:`system_toolchain_motivation_deprecating_dummy`
 Specifying dependencies using ``system`` toolchain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To make EasyBuild resolve a dependency using the ``system`` toolchain, either specify '``system``' as toolchain name
-in the tuple representing the dependency specification, or simply use ``True`` as 4th value in the tuple.
+To make EasyBuild resolve a dependency using the ``system`` toolchain, simply use the ``SYSTEM`` template constant as
+the 4th value in the tuple representing the dependency specification.
 
 For example, to specify PnMPI version 1.2.0 built with the ``system`` toolchain as a (runtime) dependency::
 
-  dependencies = [('PnMPI', '1.2.0', '', ('system', ''))]
-
-which is equivalent to::
-
-  dependencies = [('PnMPI', '1.2.0', '', True)]
+  dependencies = [('PnMPI', '1.2.0', '', SYSTEM)]
 
 
 Using external modules as dependencies


### PR DESCRIPTION
update docs to reflect https://github.com/easybuilders/easybuild-easyconfigs/issues/16330, https://github.com/easybuilders/easybuild-easyconfigs/pull/16384, https://github.com/easybuilders/easybuild-easyconfigs/pull/16386