### PR TITLE
ci(lint): add shell linter - Differential ShellCheck

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,3 +18,18 @@ jobs:
 
     - name: Run flake8 to verify PEP8-compliance of Python code
       run: flake8 -j3
+
+  shell-linting:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Run ShellCheck
+      uses: redhat-plumbers-in-action/differential-shellcheck@v3
+      with:
+        severity: warning
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs **differential ShellCheck scans** on shell scripts changed via PR and reports results directly in PR. The beauty of differential scans is that you will get **reports only about newly added defects**. 

Since this repository has few shell scripts, I think you might find some value in having a shell linter. Differential ShellCheck action is able to produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, please see below.

![image](https://user-images.githubusercontent.com/2879818/183250924-b24fdcf1-c10c-4e7a-b4e5-76f25c1e06a0.png)

![image](https://user-images.githubusercontent.com/2879818/183250933-27cd182f-47f5-42fd-a2e6-1789bf5c3fc3.png)

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting. I'm always happy to extend functionality.