### PR TITLE
fix typo on Python 2 vs 3 page

### DIFF
--- a/docs/Python-2-3-compatibility.rst
+++ b/docs/Python-2-3-compatibility.rst
@@ -226,7 +226,7 @@ Function to raise an error with specified message and traceback, implemented in 
 -------------
 
 * Python 2: corresponds to ``urllib.urlencode`` function
-* Python 2: corresponds to ``urllib.parse.urlencode`` function
+* Python 3: corresponds to ``urllib.parse.urlencode`` function
 
 .. _py2vs3_URLError:
 


### PR DESCRIPTION
Spotted while reviewing the Mkdocs porting of this page (https://github.com/easybuilders/easybuild-docs/pull/70)