### PR TITLE
 Cancel GithubAction runs for outdated commits 

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -2,6 +2,10 @@ name: Docs build and installation end-to-end tests
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,10 @@
 name: Static Analysis
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   python-linting:
     runs-on: ubuntu-18.04

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,5 +1,10 @@
 name: Tests for scripts
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Save (free) CPU hours by canceling running actions on the same branch, e.g. after a re-push on a PR