### PR TITLE
Fix indentation in Easystack examples

### DIFF
--- a/docs/Easystack-files.rst
+++ b/docs/Easystack-files.rst
@@ -70,13 +70,13 @@ For example:
 
   easyconfigs:
     - PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb:
-      options:
-        from-pr: 15924
-        debug: True
+        options:
+          from-pr: 15924
+          debug: True
     - Hypre-2.25.0-foss-2022a.eb:
     - OpenFOAM-v2206-foss-2022a.eb:
-      options:
-        installpath: /my/custom/installpath
+        options:
+          installpath: /my/custom/installpath
 
 .. note::
    You need to take care with some values in YAML, especially integers, booleans, etc.
@@ -108,8 +108,8 @@ Specifying short options in an easystack file is allowed, for example:
 
   easyconfigs:
     - OpenFOAM-v2206-foss-2022a.eb:
-      options:
-        D: True
+        options:
+          D: True
 
 This is not recommended however, as short options are more difficult to interpret by humans.
 
@@ -127,9 +127,9 @@ These apply to *all* items in the easystack file. For example, if you have an ea
 
   easyconfigs:
     - PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb:
-      options:
-        from-pr: 15924
-        debug: True
+        options:
+          from-pr: 15924
+          debug: True
     - OpenFOAM-v2206-foss-2022a.eb:
 
 and you run with
@@ -180,8 +180,8 @@ In the future, we are planning to support additional also global options specifi
     robot: True
 
   easyconfigs:
-  - PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb
-  - OpenFOAM-v2206-foss-2022a.eb
+    - PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb
+    - OpenFOAM-v2206-foss-2022a.eb
 
 would installed both ``PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb`` and ``OpenFOAM-v2206-foss-2022a.eb`` using ``--robot``
 (see `issue #4105 <https://github.com/easybuilders/easybuild-framework/issues/4105>`_).


### PR DESCRIPTION
The examples with the additional `options` don't work, e.g. the first one from https://docs.easybuild.io/en/latest/Easystack-files.html#combining-command-line-options-with-options-in-an-easystack-file results in:
```
ERROR: Failed to parse easystack file: expected a dictionary with one key (the EasyConfig name), instead found keys: PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb, options, see https://docs.easybuild.io/en/latest/Easystack-files.html for documentation.
```

Looking at an example from the tests at https://github.com/easybuilders/easybuild-framework/blob/develop/test/framework/easystacks/test_easystack_easyconfigs_opts.yaml, the additional options need more indentation, and the following does indeed work:
```
easyconfigs:
  - PyTorch-1.12.0-foss-2022a-CUDA-11.7.0.eb:
      options:
        from-pr: 15924
        debug: True
  - OpenFOAM-v2206-foss-2022a.eb:

```