### PR TITLE
fix `create_source_tarball.sh` script to be compatible with recent setuptools versions

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -120,7 +120,7 @@ jobs:
 
         # script should fail if expected source tarball did not get created in dist/
         ($GITHUB_WORKSPACE/scripts/create_source_tarball.sh ${{matrix.repo}} $version 2>&1 | tee $out) || true
-        grep "ERROR: Expected file dist/${{matrix.repo}}-${version}.tar.gz not found!" $out
+        grep "ERROR: No source tarball for ${{matrix.repo}} ${version} found" $out
         echo "Expected error found in output: OK!"
 
         # clean up index file, to avoid check for dirty working directory failing

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -209,12 +209,17 @@ fi
 
 # sanity checks on source tarball
 cd $tmpdir; tar xfz $cwd/$sdist_tar_gz; cd - > /dev/null
-unpacked_sdist=$tmpdir/${repo_underscore}-${version}
-echo -n ">> checking for unpacked source tarball at $unpacked_sdist ... "
-if [ -d $unpacked_sdist ]; then
-    ok
-else
-    error "Expected unpacked source tarball at $unpacked_sdist, not found!"
+for unpacked_sdist in $tmpdir/${repo_underscore}-${version} $tmpdir/${repo}-${version}; do
+    echo -n ">> checking for unpacked source tarball at $unpacked_sdist ... "
+    if [ -d $unpacked_sdist ]; then
+        ok
+        break
+    else
+        warning "Unpacked source tarball at $unpacked_sdist not found!"
+    fi
+done
+if [ ! -d $unpacked_sdist ]; then
+    error "No unpacked source tarball found for ${repo} ${version} in $tmpdir!"
 fi
 
 if [[ "$repo" == "easybuild-easyconfigs" ]]; then


### PR DESCRIPTION
Recent versions of setuptools (>= 69.0.3, not sure?) 'normalize' package names by replacing dashes with underscores, so we source tarballs like `easybuild_framework-4.9.2.tar.gz` instead of `easybuild-framework-4.9.2.tar.gz`.

The changes being made here accept both, just to stay compatible with older setuptools versions (or in case they change their mind again...)

edit: see also https://github.com/easybuilders/easybuild-easyblocks/pull/3358