### PR TITLE
bump version to 4.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ from distutils.core import setup
 
 # note: release candidates should be versioned as a pre-release, e.g. "1.1rc1"
 # 1.1-rc1 would indicate a post-release, i.e., and update of 1.1, so beware
-VERSION = '4.9.1'
+VERSION = '4.9.2'
 
 
 # Utility function to read README file


### PR DESCRIPTION
This is just to publish EasyBuild v4.9.2 on PyPI (see https://pypi.org/project/easybuild/4.9.2)